### PR TITLE
No need to publish .snupkg separately

### DIFF
--- a/.github/workflows/CI-CD.yml
+++ b/.github/workflows/CI-CD.yml
@@ -85,4 +85,4 @@ jobs:
         path: artifacts
 
     - name: Publish to Nuget
-      run: dotnet nuget push artifacts/SIL.PasswordStore.NuGetPackage/*.*nupkg -s https://api.nuget.org/v3/index.json -k ${{secrets.SILLSDEV_PUBLISH_NUGET_ORG}} --skip-duplicate
+      run: dotnet nuget push artifacts/SIL.PasswordStore.NuGetPackage/*.nupkg -s https://api.nuget.org/v3/index.json -k ${{secrets.SILLSDEV_PUBLISH_NUGET_ORG}} --skip-duplicate


### PR DESCRIPTION
Pushing the .nuget file also uploads the .snupkg file, so we don't
need to push that separately.